### PR TITLE
Fix undefined and unconnected types when creating client schema from SDL

### DIFF
--- a/src/jointjs/index.ts
+++ b/src/jointjs/index.ts
@@ -272,7 +272,7 @@ export default class JointJS {
         if (activeType === type.name) {
           return true;
         }
-        if (type.constructor.name === "GraphQLObjectType") {
+        if (type.constructor.name === "GraphQLObjectType" || type instanceof GraphQLObjectType) {
           return (
             isRelatedType(type as GraphQLObjectType, typeMap[activeType]) ||
             isRelatedType(typeMap[activeType] as GraphQLObjectType, type)
@@ -320,7 +320,10 @@ export default class JointJS {
           const field = fields[k];
           const connectedType = getNestedType(field.type);
           const id = getPortId(type, field, connectedType);
-          const label = getFieldLabel(field.type);
+          let label = getFieldLabel(field.type);
+          if (!label || label === 'undefined') {
+            label = getFieldLabel(connectedType)
+          }
           return {
             id,
             label


### PR DESCRIPTION
Hey!

Used your lib to create a VSCode extension that shows birdseye and refreshes when you edit your graphql sdl file.

It's still early stages but I've found some issues with unconnected and undefined types when transpiling sdl with graphql-tag and building it using the buildASTSchema.
Most issues are probably related to minification process changing constructor names and the fact that the code base relied on constructor names. 
In this PR, I've fixed those issues. (without breaking functionality hopefully :))

Thanks for this lib and I hope to see it evolve to something cool 👍 